### PR TITLE
README: Simpler connect scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,8 @@ or from docker hub
 
     docker run -p=7711:7711 -d -P jobflow/disque
 
+To connect run:
+
     ./disque -p 7711
+or
+    redis-cli -p 7711

--- a/README.md
+++ b/README.md
@@ -25,21 +25,10 @@ Currently (27 April 2015) the project is just an alpha quality preview, that was
     docker build -t="jobflow-disque:Dev" .
  
 ## Run Server
-    docker run -d jobflow-disque:Dev
+    docker run -p=7711:7711 -d jobflow-disque:Dev
 
 or from docker hub
 
-    docker run -i -t -d -P jobflow/disque
+    docker run -p=7711:7711 -d -P jobflow/disque
 
-## Connect
-Find the ip of the running container
-
-    docker ps
-
-    CONTAINER ID        IMAGE                   COMMAND             CREATED             STATUS              PORTS                     NAMES
-
-    123456786765        jobflow-disque:v0.1.1   disque-server     2 minutes ago       Up 2 minutes        0.0.0.0:49153->7711/tcp   tender_banana
-
-To connect run:
-
-    ./disque -p 49153 -h [DOCKER_IP_ADDRESS]
+    ./disque -p 7711

--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ To connect run:
 
     ./disque -p 7711
 or
+
     redis-cli -p 7711


### PR DESCRIPTION
Docker run has a port forwarding scheme. Make use of that in the README.
